### PR TITLE
Add overloads for int8_t and uint8_t

### DIFF
--- a/include/boost/endian/conversion.hpp
+++ b/include/boost/endian/conversion.hpp
@@ -35,9 +35,11 @@ namespace endian
   
   // reverse byte order (i.e. endianness)
   //   
+  inline int8_t  reverse_value(int8_t x) BOOST_NOEXCEPT;
   inline int16_t  reverse_value(int16_t x) BOOST_NOEXCEPT;
   inline int32_t  reverse_value(int32_t x) BOOST_NOEXCEPT;
   inline int64_t  reverse_value(int64_t x) BOOST_NOEXCEPT;
+  inline uint8_t reverse_value(uint8_t x) BOOST_NOEXCEPT;
   inline uint16_t reverse_value(uint16_t x) BOOST_NOEXCEPT;
   inline uint32_t reverse_value(uint32_t x) BOOST_NOEXCEPT;
   inline uint64_t reverse_value(uint64_t x) BOOST_NOEXCEPT;
@@ -87,14 +89,8 @@ namespace endian
   
   // reverse byte order (i.e. endianness)
   //   
-  inline void reverse(int16_t& x) BOOST_NOEXCEPT;
-  inline void reverse(int32_t& x) BOOST_NOEXCEPT;
-  inline void reverse(int64_t& x) BOOST_NOEXCEPT;
-  inline void reverse(uint16_t& x) BOOST_NOEXCEPT;
-  inline void reverse(uint32_t& x) BOOST_NOEXCEPT;
-  inline void reverse(uint64_t& x) BOOST_NOEXCEPT;
-  inline void reverse(float& x) BOOST_NOEXCEPT;
-  inline void reverse(double& x) BOOST_NOEXCEPT;   
+  template <class Value>
+  inline void reverse(Value& x) BOOST_NOEXCEPT;
 
   //  reverse unless native endianness is big
   template <class Reversible>
@@ -157,6 +153,11 @@ namespace endian
 //       who provided his Boost licensed macro implementation (detail/intrinsic.hpp)    //
 //                                                                                      //
 //--------------------------------------------------------------------------------------//
+
+  inline int8_t reverse_value(int8_t x) BOOST_NOEXCEPT
+  {
+    return x;
+  }
                                                 
   inline int16_t reverse_value(int16_t x) BOOST_NOEXCEPT
   {
@@ -193,6 +194,11 @@ namespace endian
 # else
     return BOOST_ENDIAN_INTRINSIC_BYTE_SWAP_8(static_cast<uint64_t>(x));
 # endif
+  }
+  
+  inline uint8_t reverse_value(uint8_t x) BOOST_NOEXCEPT
+  {
+    return x;
   }
 
   inline uint16_t reverse_value(uint16_t x) BOOST_NOEXCEPT
@@ -379,14 +385,8 @@ namespace endian
   
   // reverse byte order (i.e. endianness)
   //   
-  inline void reverse(int16_t& x) BOOST_NOEXCEPT   {x = reverse_value(x);}
-  inline void reverse(int32_t& x) BOOST_NOEXCEPT   {x = reverse_value(x);}
-  inline void reverse(int64_t& x) BOOST_NOEXCEPT   {x = reverse_value(x);}
-  inline void reverse(uint16_t& x) BOOST_NOEXCEPT  {x = reverse_value(x);}
-  inline void reverse(uint32_t& x) BOOST_NOEXCEPT  {x = reverse_value(x);}
-  inline void reverse(uint64_t& x) BOOST_NOEXCEPT  {x = reverse_value(x);}
-  inline void reverse(float& x) BOOST_NOEXCEPT     {x = reverse_value(x);}
-  inline void reverse(double& x) BOOST_NOEXCEPT    {x = reverse_value(x);}   
+  template <class Value>
+  inline void reverse(Value& x) BOOST_NOEXCEPT {x = reverse_value(x);}
 
   //  reverse unless native endianness is big
   template <class Reversible>


### PR DESCRIPTION
- The overloads for int8_t and uint8_t types are useful for generic programming.
- Code factorization: Templated the reverse function (same body in each overloads).
