### PR TITLE
guard macro definition

### DIFF
--- a/test/loop_time_test.cpp
+++ b/test/loop_time_test.cpp
@@ -7,7 +7,9 @@
 
 //--------------------------------------------------------------------------------------//
 
+#if !defined(_SCL_SECURE_NO_WARNINGS)
 #define _SCL_SECURE_NO_WARNINGS
+#endif
 
 //#define BOOST_ENDIAN_NO_INTRINSICS
 //#define BOOST_ENDIAN_LOG

--- a/test/speed_test.cpp
+++ b/test/speed_test.cpp
@@ -7,7 +7,9 @@
 
 //--------------------------------------------------------------------------------------//
 
+#if !defined(_SCL_SECURE_NO_WARNINGS)
 #define _SCL_SECURE_NO_WARNINGS
+#endif
 
 #define BOOST_ENDIAN_NO_INTRINSICS
 //#define BOOST_ENDIAN_LOG

--- a/test/speed_test_functions.cpp
+++ b/test/speed_test_functions.cpp
@@ -13,7 +13,9 @@
 
 //--------------------------------------------------------------------------------------//
 
+#if !defined(_SCL_SECURE_NO_WARNINGS)
 #define _SCL_SECURE_NO_WARNINGS
+#endif
 
 #include "speed_test_functions.hpp"
 


### PR DESCRIPTION
_SCL_SECURE_NO_WARNINGS might be defined on the command line by users.