### PR TITLE
Fix a few typos

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -458,7 +458,7 @@ performing a lot of arithmetic operations on the endian arithmetic types.</p>
 <p><b>What is gained by using the buffer types rather than always just using the 
 arithmetic types?</b></p>
 <blockquote>
-<p>Assurance than hidden conversions are not performed. This is of overriding 
+<p>Assurance that hidden conversions are not performed. This is of overriding 
 importance to users concerned about achieving the ultimate in terms of speed. </p>
 <p>&quot;Always just using the arithmetic types&quot; is fine for other users. When the 
 ultimate in speed needs to be ensured, the arithmetic types can be used in the 

--- a/include/boost/endian/conversion.hpp
+++ b/include/boost/endian/conversion.hpp
@@ -50,7 +50,7 @@ namespace endian
 //--------------------------------------------------------------------------------------//
   
   //  customization for exact-length arithmetic types. See doc/conversion.html/#FAQ.
-  //  Note: The omission of an overloads for the arithmetic type (typically long, or
+  //  Note: The omission of a overloads for the arithmetic type (typically long, or
   //  long long) not assigned to one of the exact length typedefs is a deliberate
   //  design decision. Such overloads would be non-portable and thus error prone.
      

--- a/include/boost/endian/conversion.hpp
+++ b/include/boost/endian/conversion.hpp
@@ -98,7 +98,7 @@ namespace endian
   //------------------------------------------------------------------------------------//
 
 
-  //  Q: What happended to bswap, htobe, and the other synonym functions based on names
+  //  Q: What happened to bswap, htobe, and the other synonym functions based on names
   //     popularized by BSD, OS X, and Linux?
   //  A: Turned out these may be implemented as macros on some systems. Ditto POSIX names
   //     for such functionality. Since macros would cause endless problems with functions

--- a/test/endian_operations_test.cpp
+++ b/test/endian_operations_test.cpp
@@ -12,7 +12,7 @@
 //  This test probes operator overloading, including interaction between
 //  operand types.
 
-//  See endian_test for tests of endianess correctness, size, and value.
+//  See endian_test for tests of endianness correctness, size, and value.
 
 #define BOOST_ENDIAN_LOG
 

--- a/test/endian_test.cpp
+++ b/test/endian_test.cpp
@@ -9,7 +9,7 @@
 
 //----------------------------------------------------------------------------//
 
-//  This test probes for correct endianess, size, and value.
+//  This test probes for correct endianness, size, and value.
 
 //  See endian_operations_test for tests of operator correctness and interaction
 //  between operand types.


### PR DESCRIPTION
Separate commits because some typos were found in an automated fashion, some not.  I'd like to give credits to [codespell](https://github.com/lucasdemarchi/codespell/) where it's due.

Please note that the `endianess` vs `endianness` issue seems to only occur at these few points, so it's mostly spelled correctly.  Source for the spelling of `endianness`:
- Merriam Webster: doesn't know that word
- [Wikipedia](https://en.wikipedia.org/w/index.php?title=Endianess&redirect=no)
- [English Google](https://www.google.com/search?q=endianess&ie=utf-8&oe=utf-8&hl=en)
- Stackoverflow: [1.4k time Endianess](https://stackoverflow.com/search?q=endianess) vs [14k times Endianness](https://stackoverflow.com/search?q=endianness)