### PR TITLE
remove unaligned loads and stores on x86

### DIFF
--- a/include/boost/endian/buffers.hpp
+++ b/include/boost/endian/buffers.hpp
@@ -278,17 +278,13 @@ namespace endian
     T load_little_endian(const void* bytes) BOOST_NOEXCEPT
     {
 #   if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
-      // On x86 (which is little endian), unaligned loads are permitted
-      if (sizeof(T) == n_bytes)  // GCC 4.9, VC++ 14.0, and probably others, elide this
-                                 // test and generate code only for the applicable return
-                                 // case since sizeof(T) and n_bytes are known at compile
-                                 // time.
-      {
-        return *reinterpret_cast<T const *>(bytes);
-      }
-#   endif
+      T ret;
+      std::memcpy(&ret, bytes, n_bytes);
+      return ret;
+#    else
       return unrolled_byte_loops<T, n_bytes>::load_little
         (static_cast<const unsigned char*>(bytes));
+#    endif
     }
 
     template <typename T, std::size_t n_bytes>
@@ -304,18 +300,11 @@ namespace endian
     void store_little_endian(void* bytes, T value) BOOST_NOEXCEPT
     {
 #     if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
-      // On x86 (which is little endian), unaligned stores are permitted
-      if (sizeof(T) == n_bytes)  // GCC 4.9, VC++ 14.0, and probably others, elide this
-                                 // test and generate code only for the applicable return
-                                 // case since sizeof(T) and n_bytes are known at compile
-                                 // time.
-      {
-        *reinterpret_cast<T *>(bytes) = value;
-        return;
-      }
-#     endif
+      std::memcpy(bytes, &value, n_bytes);
+#     else
       unrolled_byte_loops<T, n_bytes>::store_little
         (static_cast<char*>(bytes), value);
+#     endif
     }
 
   } // namespace detail


### PR DESCRIPTION
It invokes undefined behavior regardless of the compiler back-end. more details in #21 