### PR TITLE
add test to expose undefined behaviors in endian_buffer

### DIFF
--- a/test/buffer_test.cpp
+++ b/test/buffer_test.cpp
@@ -18,6 +18,7 @@
 #include <boost/cstdint.hpp>
 #include <iostream>
 #include <sstream>
+#include <limits>
 
 using namespace boost::endian;
 using std::cout;
@@ -198,6 +199,23 @@ namespace
     std::cout << "test construction and assignment" << std::endl;
   }
 
+  template <typename Int>
+  void test_boundary_values()
+  {
+    endian_buffer<order::big, Int, sizeof(Int) * CHAR_BIT, align::no> bmax(
+      std::numeric_limits<Int>::max());
+    endian_buffer<order::big, Int, sizeof(Int) * CHAR_BIT, align::no> bmin(
+      std::numeric_limits<Int>::min());
+    endian_buffer<order::little, Int, sizeof(Int) * CHAR_BIT, align::no> lmax(
+      std::numeric_limits<Int>::max());
+    endian_buffer<order::little, Int, sizeof(Int) * CHAR_BIT, align::no> lmin(
+      std::numeric_limits<Int>::min());
+
+    BOOST_TEST(bmax.value() == std::numeric_limits<Int>::max());
+    BOOST_TEST(bmin.value() == std::numeric_limits<Int>::min());
+    BOOST_TEST(lmax.value() == std::numeric_limits<Int>::max());
+    BOOST_TEST(lmin.value() == std::numeric_limits<Int>::min());
+  }
 }  // unnamed namespace
 
 //--------------------------------------------------------------------------------------//
@@ -229,6 +247,13 @@ int cpp_main(int, char *[])
   check_size();
   test_inserter_and_extractor();
   test_construction_and_assignment();
+
+  test_boundary_values<signed int>();
+  test_boundary_values<unsigned int>();
+  test_boundary_values<signed short>();
+  test_boundary_values<unsigned short>();
+  test_boundary_values<signed char>();
+  test_boundary_values<unsigned char>();
 
   cout << "  done" << endl;
 


### PR DESCRIPTION
when instantiated with signed integers, ``endian_buffer`` performs right- and left shifts directly on those signed integers. For negative values, this invokes undefined- and implementation defined behavior.

In my mind, the best solution is to avoid all bitwise-operators on signed integer types (and I count the shift operators as bitwise because of their restrictions).

I propose all *values* are cast to its storage type, or an unsigned counterpart of themselves. All bit shifting and masking should be performed on the unsigned types.

Here's an example output from running the tests added in this PR:

``bjam cxxflags=-fsanitize=undefined linkflags=-fsanitize=undefined``

```buffers.hpp:225:75: runtime error: left shift of negative value -128
buffers.hpp:225:75: runtime error: left shift of negative value -32768
buffers.hpp:225:75: runtime error: left shift of negative value -8388608
buffers.hpp:225:75: runtime error: left shift of negative value -128
```

This issue is somewhat related to https://github.com/boostorg/endian/issues/19 in that a generic solution would be to explicitly define an interface between the value type and its corresponding storage type.
