### PR TITLE
Add non-const data() method to endian_buffer

### DIFF
--- a/include/boost/endian/buffers.hpp
+++ b/include/boost/endian/buffers.hpp
@@ -374,6 +374,7 @@ namespace endian
           return detail::load_big_endian<T, n_bits/8>(m_value);
         }
         const char* data() const BOOST_NOEXCEPT  { return m_value; }
+        char* data() BOOST_NOEXCEPT  { return m_value; }
       protected:
         char m_value[n_bits/8];
     };
@@ -409,6 +410,7 @@ namespace endian
           return detail::load_little_endian<T, n_bits/8>(m_value);
         }
         const char* data() const BOOST_NOEXCEPT  { return m_value; }
+        char* data() BOOST_NOEXCEPT  { return m_value; }
       protected:
         char m_value[n_bits/8];
     };
@@ -456,6 +458,8 @@ namespace endian
         }
         const char* data() const BOOST_NOEXCEPT
           {return reinterpret_cast<const char*>(&m_value);}
+        char* data() BOOST_NOEXCEPT
+          {return reinterpret_cast<char*>(&m_value);}
       protected:
         T m_value;
     };
@@ -497,6 +501,8 @@ namespace endian
         }
         const char* data() const BOOST_NOEXCEPT
           {return reinterpret_cast<const char*>(&m_value);}
+        char* data() BOOST_NOEXCEPT
+          {return reinterpret_cast<char*>(&m_value);}
       protected:
         T m_value;
     };


### PR DESCRIPTION
Allow users directly read data into endian_buffer through non-const data() method.

As described in the docs, endian_buffer is designed to be memcpyable. It is quite reasonable for users to pretend that the buffer point by non-const endian_buffer data() method would also be non-const. And may thus come up with following attempts, trying to access endian_buffer.

```c++
    boost::endian::big_int32_buf_t i(123);
    boost::endian::big_int32_buf_t j(456);

    // works
    std::cout.write(i.data(), sizeof(i));

    // doesn't work, since istream::read requires i.data() to be a pointer to non-const char
    std::cin.read(i.data(), sizeof(i));

    // works as describe in docs
    std::memcpy(&i, &j, sizeof(i));

    // doesn't work, same reason above
    std::memcpy(i.data(), j.data(), sizeof(i));
```

It feels like there are some inconsistencies when it comes to accessing endian_buffer.

This is just my humble opinion though. I think it would be better to add non-const data() method into endian_buffer.

Or maybe there are some further design decisions that I don't take into considerations?
