### PR TITLE
Fix BOOST_STATIC_ASSERT with template arguments

### DIFF
--- a/include/boost/endian/detail/endian_reverse.hpp
+++ b/include/boost/endian/detail/endian_reverse.hpp
@@ -108,7 +108,7 @@ inline uint128_type BOOST_ENDIAN_CONSTEXPR endian_reverse_impl( uint128_type x )
 
 template<class T> inline BOOST_CONSTEXPR T endian_reverse( T x ) BOOST_NOEXCEPT
 {
-    BOOST_STATIC_ASSERT( is_integral<T>::value && !is_same<T, bool>::value );
+    BOOST_STATIC_ASSERT( is_integral<T>::value && !(is_same<T, bool>::value) );
 
     typedef typename detail::integral_by_size< sizeof(T) >::type uintN_t;
 


### PR DESCRIPTION
a2025a932 introduced a `BOOST_STATIC_ASSERT`-check with a template argument list. This causes a compilation error in a pre-C++11 compiler without support for variadic arguments (i.e. if `BOOST_NO_CXX11_VARIADIC_MACROS` is set).

For example:
```bash
$ echo '#include <boost/endian/buffers.hpp>' > test.cpp
$ g++ -c -std=c++03 -DBOOST_NO_CXX11_VARIADIC_MACROS -I/path/to/boost test.cpp
```

results in:

```
In file included from /path/to/boost/boost/endian/detail/endian_store.hpp:9,
                 from /path/to/boost/boost/endian/buffers.hpp:30,
                 from test.cpp:1:
/path/to/boost/boost/endian/detail/endian_reverse.hpp:111:76: error: macro "BOOST_STATIC_ASSERT" passed 2 arguments, but takes just 1
  111 |     BOOST_STATIC_ASSERT( is_integral<T>::value && !is_same<T, bool>::value );
      |                                                                            ^
In file included from /path/to/boost/boost/endian/detail/endian_reverse.hpp:13,
                 from /path/to/boost/boost/endian/detail/endian_store.hpp:9,
                 from /path/to/boost/boost/endian/buffers.hpp:30,
                 from test.cpp:1:
/path/to/boost/boost/static_assert.hpp:157: note: macro "BOOST_STATIC_ASSERT" defined here
  157 | #     define BOOST_STATIC_ASSERT( B ) \
      |
```