### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC and __CODEGEARC__ to BOOST_CODE…

### DIFF
--- a/include/boost/endian/arithmetic.hpp
+++ b/include/boost/endian/arithmetic.hpp
@@ -36,7 +36,7 @@
 #include <iosfwd>
 #include <climits>
 
-#if defined(__BORLANDC__) || defined( __CODEGEARC__)
+#if defined(BOOST_BORLANDC) || defined( BOOST_CODEGEARC)
 # pragma pack(push, 1)
 #endif
 
@@ -327,7 +327,7 @@ public:
 } // namespace endian
 } // namespace boost
 
-#if defined(__BORLANDC__) || defined( __CODEGEARC__)
+#if defined(BOOST_BORLANDC) || defined( BOOST_CODEGEARC)
 # pragma pack(pop)
 #endif
 

--- a/include/boost/endian/buffers.hpp
+++ b/include/boost/endian/buffers.hpp
@@ -38,7 +38,7 @@
 #include <climits>
 #include <cstring>
 
-#if defined(__BORLANDC__) || defined( __CODEGEARC__)
+#if defined(BOOST_BORLANDC) || defined( BOOST_CODEGEARC)
 # pragma pack(push, 1)
 #endif
 
@@ -367,7 +367,7 @@ public:
 } // namespace endian
 } // namespace boost
 
-#if defined(__BORLANDC__) || defined( __CODEGEARC__)
+#if defined(BOOST_BORLANDC) || defined( BOOST_CODEGEARC)
 # pragma pack(pop)
 #endif
 


### PR DESCRIPTION
…GEARC, which are defined in Boost config for the Embarcadero non-clang-based compilers.