### PR TITLE
Fix BOOST_STATIC_ASSERT when passing enums (regression)

### DIFF
--- a/include/boost/endian/conversion.hpp
+++ b/include/boost/endian/conversion.hpp
@@ -149,7 +149,7 @@ namespace detail
 {
 
 template<class T> struct is_endian_reversible: boost::integral_constant<bool,
-    boost::is_class<T>::value || ( boost::is_integral<T>::value && !boost::is_same<T, bool>::value )>
+    boost::is_class<T>::value || ( (boost::is_integral<T>::value || boost::is_enum<T>::value) && !boost::is_same<T, bool>::value )>
 {
 };
 
@@ -221,7 +221,7 @@ namespace detail
 {
 
 template<class T> struct is_endian_reversible_inplace: boost::integral_constant<bool,
-    boost::is_class<T>::value || ( boost::is_integral<T>::value && !boost::is_same<T, bool>::value )>
+    boost::is_class<T>::value || ( (boost::is_integral<T>::value || boost::is_enum<T>::value) && !boost::is_same<T, bool>::value )>
 {
 };
 


### PR DESCRIPTION
Boost 1.71.0 introduced a regression that breaks the ability to reverse enum types.

For example:
```cpp
#include <boost/endian/conversion.hpp>

enum class Foo { BAR };

int main() {
    Foo bar { Foo::BAR };
    boost::endian::native_to_little_inplace(bar);
}
```

Under 1.70, this compiles but under 1.71:
```
In file included from /opt/wandbox/boost-1.71.0/gcc-head/include/boost/endian/detail/endian_reverse.hpp:13,
                 from /opt/wandbox/boost-1.71.0/gcc-head/include/boost/endian/conversion.hpp:11,
                 from prog.cc:1:
/opt/wandbox/boost-1.71.0/gcc-head/include/boost/endian/conversion.hpp: In instantiation of 'void boost::endian::native_to_little_inplace(EndianReversibleInplace&) [with EndianReversibleInplace = Foo]':
prog.cc:7:48:   required from here
/opt/wandbox/boost-1.71.0/gcc-head/include/boost/endian/conversion.hpp:330:89: error: static assertion failed: detail::is_endian_reversible_inplace<EndianReversibleInplace>::value
  330 |     BOOST_STATIC_ASSERT( detail::is_endian_reversible_inplace<EndianReversibleInplace>::value );
      |                                                                                         ^~~~~
/opt/wandbox/boost-1.71.0/gcc-head/include/boost/static_assert.hpp:70:55: note: in definition of macro 'BOOST_STATIC_ASSERT'
   70 | #     define BOOST_STATIC_ASSERT( ... ) static_assert(__VA_ARGS__, #__VA_ARGS__)
      |                                                       ^~~~~~~~~~~

```