### PR TITLE
Split test libraries to own lines

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,10 @@ include(BoostTestJamfile OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
 
 if(HAVE_BOOST_TEST)
 
-boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES Boost::endian Boost::core Boost::type_traits)
+boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES
+  Boost::endian
+  Boost::core
+  Boost::type_traits
+)
 
 endif()


### PR DESCRIPTION
Similar to the main CML.

Required for https://github.com/boostorg/cmake/pull/86